### PR TITLE
Fix for non-continuous segment numbering

### DIFF
--- a/Source/debug.info.writer.pdb.pas
+++ b/Source/debug.info.writer.pdb.pas
@@ -1582,8 +1582,9 @@ begin
     EmitLinkerSymbol;
 
     // Emit S_SECTION for all segments
-    for var Segment in FDebugInfo.Segments do
+    for var Segment in FDebugInfo.Segments do begin
       EmitSectionSymbol(Segment);
+    end;
 
   end else
   begin
@@ -2016,7 +2017,7 @@ begin
     FFiler.BeginFile;
 
 
-    FLinkerModule := TDebugInfoLinkerModule.Create(FDebugInfo, sLinkerModuleName, FDebugInfo.Segments[1], 0, 0);
+    FLinkerModule := TDebugInfoLinkerModule.Create(FDebugInfo, sLinkerModuleName, FDebugInfo.Segments.FindBySegmentID(1), 0, 0);
     try
 
       // Populate string list with all source file names. The list is emitted in WritePDBStrings.


### PR DESCRIPTION
Hi Anders,

I'm not sure if this really works in all corners of the code: However, there was an additional issue that the segment index 000A created 10 segments in TDebugInfoSegments, when there are only 6.

 Start         Length     Name                   Class
 0001:00401000 0025320CH .text                   CODE
 0002:00655000 00001610H .itext                  ICODE
 0003:00657000 000093F8H .data                   DATA
 0004:00661000 0000602CH .bss                    BSS
 0005:00000000 00000150H .tls                    TLS
 000A:00000000 00000000H .xdata                  PDATA

I changed TDebugInfoSegments accordingly, but I'm not sure if there are places in writing the PDB where an index (0..Count-1) is used instead of TDebugInfoSegment.Index.