### PR TITLE
EIntOverflow on reading MAP file

### DIFF
--- a/Source/debug.info.pas
+++ b/Source/debug.info.pas
@@ -617,7 +617,7 @@ begin
   FOrdered := TList<TDebugInfoSegment>.Create(TComparer<TDebugInfoSegment>.Construct(
     function(const A, B: TDebugInfoSegment): integer
     begin
-      Result := A.Index - B.Index;
+      Result := integer(Int64(A.Index) - Int64(B.Index));
     end));
 end;
 


### PR DESCRIPTION
Prevent integer over-/underflow error by appropriate casting