### PR TITLE
This adjustment corrects issues for versions 10.4 and below.

### DIFF
--- a/Source/debug.info.reader.map.pas
+++ b/Source/debug.info.reader.map.pas
@@ -19,6 +19,16 @@ uses
   debug.info.log;
 
 type
+
+  {$IF CompilerVersion < 35.0)}
+  TNoRefCountObject = class(TObject, IInterface)
+  protected
+    function QueryInterface(const IID: TGUID; out Obj): HResult; stdcall;
+    function _AddRef: Integer; stdcall;
+    function _Release: Integer; stdcall;
+  end;
+  {$ENDIF}
+
   IDebugInfoLineLogger = interface
     ['{1EA6E06A-0491-4BCF-BFA5-508BC88912BD}']
     procedure Warning(const Msg: string); overload;
@@ -1050,6 +1060,27 @@ begin
     Inc(Result, Length(Marker));
 end;
 
+{$IF CompilerVersion < 35.0)}
+{ TNoRefCountObject }
+
+function TNoRefCountObject.QueryInterface(const IID: TGUID; out Obj): HResult;
+begin
+  if GetInterface(IID, Obj) then
+    Result := S_OK
+  else
+    Result := E_NOINTERFACE;
+end;
+
+function TNoRefCountObject._AddRef: Integer;
+begin
+  Result := -1;
+end;
+
+function TNoRefCountObject._Release: Integer;
+begin
+  Result := -1;
+end;
+{$ENDIF}
 
 end.
 

--- a/Source/debug.info.writer.pas
+++ b/Source/debug.info.writer.pas
@@ -48,10 +48,18 @@ type
   // in order to avoid writing junk to the pdb file.
   TSafeMemoryStream = class(TMemoryStream)
   protected
+  {$IF CompilerVersion < 35.0)}
+    function Realloc(var NewCapacity: LongInt): Pointer; override;
+  {$ELSEIF CompilerVersion >= 35.0)}
     function Realloc(var NewCapacity: NativeInt): Pointer; override;
+  {$ENDIF}
   end;
 
+{$IF CompilerVersion < 35.0)}
+function TSafeMemoryStream.Realloc(var NewCapacity: LongInt): Pointer;
+{$ELSEIF CompilerVersion >= 35.0)}
 function TSafeMemoryStream.Realloc(var NewCapacity: NativeInt): Pointer;
+{$ENDIF}
 begin
   Result := inherited Realloc(NewCapacity);
 


### PR DESCRIPTION
The "Alloc" method of TMemoryStream has its parameter of type "LongInt" up to version 10.4; from version 11 onwards, it becomes NativeInt.

The TNoRefCountObject interface does not exist before version 11.